### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -1,0 +1,9 @@
+.item-lists :hover {
+  background-color: oldlace;
+  transition: 200ms;
+}
+
+
+.item-info {
+  background-color: oldlace;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_login_page, only: :new
 
   def index
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,10 +14,10 @@ class Item < ApplicationRecord
     validates :name, length: { maximum: 40 }
     validates :explain, length: { maximum: 1000 }
   end
-  
+
   with_options numericality: { other_than: 0, message: 'を選択してください' } do
     validates :category_id, :status_id, :delivery_id, :prefecture_id, :schedule_id
   end
-  
+
   validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'は300〜9,999,999円に設定してください' }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -153,7 +153,7 @@
       <% end %>
 
       <%# 商品がない場合のダミー %>
-      <% if Item.exists? == false %>
+      <% if @items.exists? == false %>
         <li class='list'>
           <%= link_to '#' do %>
             <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,56 +125,53 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "link" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+              <%# <span>Sold Out!!</span> ※商品購入機能実装後にやる※ %>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if Item.exists? == false %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                  商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,35 +125,35 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-      <% @items.each do |item| %>
-        <li class='list'>
-          <%= link_to "link" do %>
-            <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img" if item.image.attached? %>
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <div class='sold-out'>
-              <%# <span>Sold Out!!</span> ※商品購入機能実装後にやる※ %>
+      <% if @items.exists? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to "link" do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                <%# <span>Sold Out!!</span> ※商品購入機能実装後にやる※ %>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
               </div>
-              <%# //商品が売れていればsold outを表示しましょう %>
-            </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.name %>
-              </h3>
-              <div class='item-price'>
-                <span><%= item.price %>円<br>(税込み)</span>
-                <div class='star-btn'>
-                  <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br>(税込み)</span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
                 </div>
               </div>
-            </div>
-          <% end %>
-        </li>
-      <% end %>
+            <% end %>
+          </li>
+      <% else %>
 
       <%# 商品がない場合のダミー %>
-      <% if @items.exists? == false %>
         <li class='list'>
           <%= link_to '#' do %>
             <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>


### PR DESCRIPTION
# What
itemsテーブルの中身（画像、名前、価格）が商品一覧ページに表示されるようにした。
itemsテーブルにデータが存在しない場合、ダミーが表示されるようにした。

# Why
商品一覧表示機能実装のため

## 実装した機能の様子
商品を出品すると新しい順に表示される
https://gyazo.com/b4a6e5f1e509c8af057eb9d0ce2cb92d

ログアウト状態でも商品一覧ページが見られる
https://gyazo.com/400e10682f9647bca4f07e8c50d7a8e0

商品が無い場合はダミーが表示される
https://gyazo.com/423790a9f3d0c1a4c521613c1b5b09f9