### PR TITLE
前後の商品へ遷移する機能

### DIFF
--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -284,9 +284,8 @@
 
 .links {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-around;
   width: 50vw;
-
 }
 
 .change-item-btn {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,8 @@ class ItemsController < ApplicationController
   def show
     @comment = Comment.new
     @comments = @item.comments.includes(:user)
+    @front_item = Item.front_item(@item)
+    @back_item = Item.back_item(@item)
   end
 
   def edit

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -30,4 +30,12 @@ class Item < ApplicationRecord
       Item.all
     end
   end
+
+  def self.back_item(back_item)
+    Item.where("id < ?", back_item.id).order("id DESC").first
+  end
+
+  def self.front_item(front_item)
+    Item.where("id > ?", front_item.id).order("id ASC").first
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -137,12 +137,8 @@
     <% end %>
   </div>
   <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
+    <%= link_to '＜ 前の商品', item_path(@front_item.id),class: "change-item-btn" if @front_item %>
+    <%= link_to '後ろの商品 ＞', item_path(@back_item.id),class: "change-item-btn" if @back_item %>
   </div>
   <%= link_to "#{@item.category.name}をもっと見る", category_path(category_id: @item.category_id), class: "another-item" %>
 </div>


### PR DESCRIPTION
# What
商品詳細ページ下部の「前の商品」「後ろの商品」をクリックすると、今表示している商品よりもidが大きい商品、idが小さい商品へ遷移する

# Why
前後の商品への遷移機能実装のため